### PR TITLE
Use jinjasql to prevent SQL injections

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 certifi==2020.4.5.1
 Jinja2==2.11.2
+jinjasql==0.1.8
 MarkupSafe==1.1.1
 psycopg2==2.8.5

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -1,7 +1,6 @@
 import os
 
-from jinja2 import Template
-
+from jinjasql import JinjaSql
 
 def execute_sql_from_jinja_string(conn, sql_string, context=None):
     # conn: a (psycopg2) connection object
@@ -14,12 +13,15 @@ def execute_sql_from_jinja_string(conn, sql_string, context=None):
     #
     # execute_sql_from_jinja_string(conn, "SELECT version();")
     # execute_sql_from_jinja_string(conn, "SELECT * FROM biodiv.address LIMIT {{limit}}", {'limit': 5})
+    j = JinjaSql()
+
     if context is None:
         context = {}
 
+    query, bind_params = j.prepare_query(sql_string, context)
+
     cur = conn.cursor()
-    sql_template = Template(sql_string)
-    cur.execute(sql_template.render(context))
+    cur.execute(query, bind_params)
 
     return cur
 


### PR DESCRIPTION
Hi @damianooldoni, I updated the `execute_sql_*` helpers to prevent SQL injections.

The arguments to those functions are currently unchanged, so in theory you don't even have to update your client code to use them (it works on `master`, I haven't tested on `gbif_match`).

Don't hesitate to have a quick look at [jinjasql](https://github.com/hashedin/jinjasql) documentation, since that's what we are now using. I think we might also use other features on the jinja syntax (such as for loops) to simplify some client code (for example generating a list of fields).