### PR TITLE
Add taxon tree while matching names

### DIFF
--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -73,17 +73,17 @@ def _insert_new_entry_taxonomy(conn, taxon):
 
 
 # To remove (or at least improve with dict_cursor) later during refactoring
-def _get_taxonomy_as_dict(conn):
-    taxonomy_cur = execute_sql_from_file(conn, 'get_taxa_taxonomy.sql')
-    taxonomy = taxonomy_cur.fetchall()
-    cols_taxonomy = list(map(lambda x: x[0], taxonomy_cur.description))
-    taxonomy_dict = dict()
-    if taxonomy is not None:
-        for row in taxonomy:
-            # use gbifID as key of taxonomy_dict
-            taxonomy_dict[row[1]] = dict(zip(cols_taxonomy, row))
-
-    return taxonomy_dict
+# def _get_taxonomy_as_dict(conn):
+#     taxonomy_cur = execute_sql_from_file(conn, 'get_taxa_taxonomy.sql')
+#     taxonomy = taxonomy_cur.fetchall()
+#     cols_taxonomy = list(map(lambda x: x[0], taxonomy_cur.description))
+#     taxonomy_dict = dict()
+#     if taxonomy is not None:
+#         for row in taxonomy:
+#             # use gbifID as key of taxonomy_dict
+#             taxonomy_dict[row[1]] = dict(zip(cols_taxonomy, row))
+#
+#     return taxonomy_dict
 
 
 def gbif_match(conn, config_parser, unmatched_only=True):

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -100,7 +100,7 @@ def _get_taxon_from_taxonomy_by_gbifId(conn, gbifId):
 #
 #     return taxonomy_dict
 
-def add_taxon_tree(conn, gbif_key):
+def _add_taxon_tree(conn, gbif_key):
     # find and add taxon recursively to taxonomy table
 
     taxon_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbifId=gbif_key)
@@ -129,7 +129,7 @@ def add_taxon_tree(conn, gbif_key):
             return taxon
         # taxon has parent in GBIF Backbone
         else:
-            parent = add_taxon_tree(conn, gbif_key=gbif_parentKey)
+            parent = _add_taxon_tree(conn, gbif_key=gbif_parentKey)
             # get the updated parentId
             parent_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbifId=gbif_parentKey)
             taxon['parentId'] = parent_in_taxonomy.get('id')
@@ -137,7 +137,7 @@ def add_taxon_tree(conn, gbif_key):
     else:
         # parent in GBIF Backbone not in taxonomy
         if taxon.get('parentId') is None and gbif_parentKey is not None:
-            add_taxon_tree(conn, gbif_key=gbif_parentKey)
+            _add_taxon_tree(conn, gbif_key=gbif_parentKey)
         # get the updated parentId
         parent_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbifId=gbif_parentKey)
         taxon['parentId'] = parent_in_taxonomy.get('id')
@@ -198,7 +198,7 @@ def gbif_match(conn, config_parser, unmatched_only=True):
             match_count += 1
 
             gbifId = gbif_taxon_info.get('usageKey')
-            add_taxon_tree(conn, gbifId)
+            _add_taxon_tree(conn, gbifId)
             taxon = _get_taxon_from_taxonomy_by_gbifId(conn, gbifId=gbifId)
             match_info['taxonomyId'] = taxon['id']
 

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -100,7 +100,7 @@ def gbif_match(conn, config_parser, unmatched_only=True):
                                     dict_cursor=True)
 
     # get taxonomy table and store it as a dictionary
-    taxonomy_dict = _get_taxonomy_as_dict(conn)
+    # taxonomy_dict = _get_taxonomy_as_dict(conn)
 
     total_sn_count = scientificname_cur.rowcount
     print(f"Number of taxa in scientificname table: {total_sn_count}.")

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -226,4 +226,4 @@ if __name__ == "__main__":
     config = get_config()
     setup_log_file("./logs/match_names_to_gbif_backbone_log.csv")
 
-    gbif_match(conn=connection, config_parser=config, unmatched_only=True)
+    gbif_match(conn=connection, config_parser=config, unmatched_only=False)

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -71,6 +71,21 @@ def _insert_new_entry_taxonomy(conn, taxon):
     print(f"Taxon {taxon['scientificName']} inserted in taxonomy (id = {taxonomyId}).")
     return taxonomyId
 
+def _get_taxon_from_taxonomy_by_gbifId(conn, gbifId):
+
+    # get taxon information from taxonomy by searching on gbifId
+    gbifId_to_search = {'gbifId': gbifId}
+    template = """SELECT * FROM taxonomy WHERE "gbifId" = {{ gbifId }} """
+    taxon_cur = execute_sql_from_jinja_string(conn, sql_string=template, context=gbifId_to_search)
+    taxon_values = taxon_cur.fetchall()
+    cols_taxonomy = list(map(lambda x: x[0], taxon_cur.description))
+
+    assert len(taxon_values) <= 1, f"Multiple taxa with gbifId = {gbifId} in taxonomy."
+    if len(taxon_values) == 1:
+        taxon = dict(zip(cols_taxonomy, taxon_values[0]))
+    else:
+        taxon = dict.fromkeys(cols_taxonomy)
+    return taxon
 
 # To remove (or at least improve with dict_cursor) later during refactoring
 # def _get_taxonomy_as_dict(conn):

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -3,7 +3,8 @@ CREATE TABLE taxonomy (
     "id" serial PRIMARY KEY,  -- internal (to the DB) ID
     "gbifId" integer NOT NULL, -- ID at GBIF
     "scientificName" character varying(255), -- as returned by GBIF
-    "kingdom" character varying(50)
+    "kingdom" character varying(50),
+    "parentId" integer  -- internal (to the DB) pointer
 );
 
 CREATE TYPE gbifmatchtype AS ENUM ('EXACT', 'FUZZY', 'HIGHERRANK');

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -4,7 +4,7 @@ CREATE TABLE taxonomy (
     "gbifId" integer NOT NULL, -- ID at GBIF
     "scientificName" character varying(255), -- as returned by GBIF
     "kingdom" character varying(50),
-    "parentId" integer REFERENCES id  -- internal (to the DB) pointer
+    "parentId" integer REFERENCES taxonomy(id)  -- internal (to the DB) pointer
 );
 
 CREATE TYPE gbifmatchtype AS ENUM ('EXACT', 'FUZZY', 'HIGHERRANK', 'NONE');

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -4,7 +4,7 @@ CREATE TABLE taxonomy (
     "gbifId" integer NOT NULL, -- ID at GBIF
     "scientificName" character varying(255), -- as returned by GBIF
     "kingdom" character varying(50),
-    "parentId" integer  -- internal (to the DB) pointer
+    "parentId" integer REFERENCES id  -- internal (to the DB) pointer
 );
 
 CREATE TYPE gbifmatchtype AS ENUM ('EXACT', 'FUZZY', 'HIGHERRANK', 'NONE');

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -7,7 +7,7 @@ CREATE TABLE taxonomy (
     "parentId" integer  -- internal (to the DB) pointer
 );
 
-CREATE TYPE gbifmatchtype AS ENUM ('EXACT', 'FUZZY', 'HIGHERRANK');
+CREATE TYPE gbifmatchtype AS ENUM ('EXACT', 'FUZZY', 'HIGHERRANK', 'NONE');
 -- table contains scientificnames in use in the database, a link to "taxonomy" and metadata about the taxonomic match at GBIF
 CREATE TABLE scientificname (
     "id" serial PRIMARY KEY,

--- a/scripts/transform_db.py
+++ b/scripts/transform_db.py
@@ -33,7 +33,8 @@ with conn:
     execute_sql_from_file(conn, 'populate_scientificname.sql',
                           {'limit': config.get('transform_db', 'scientificnames-limit')})
 
-    message = "Step 4: populate taxonomy table with matches to GBIF Backbone and update scientificname table"
+    message = "Step 4: populate taxonomy table with matches to GBIF Backbone and related backbone tree " +\
+              "and update scientificname table"
     print(message)
     logging.info(message)
     gbif_match.gbif_match(conn, config_parser=config, unmatched_only=False)


### PR DESCRIPTION
This PR would like the functionality of adding the taxonomic tree while matching names to GBIF.

I added a core function, `_add_taxon_tree()`, which adds a taxon and recursively its taxonomic tree if not present. Probably the name can be improved? I am not the best one in the art of naming things :name_badge: This function refactors an important part of the for loop in `gbif_match()`.

I don't get `taxonomy` table as dictionary at the beginning of `gbif_match()` anymore. So I commented the related function (which I think we could remove at the end of this PR if you agree on it). But we need a dynamic approach, so I wrote a function, `_get_taxon_from_taxonomy_by_gbifId()` to retrieve a taxon in taxonomy by searching on `gbifId`.

Please give a look and let me know.