### PR TITLE
Load exotic status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Development of the postgreSQL species database of Brussels Environment
 
 ## Changelog / development journal
 
+- Added exotic status to `taxonomy` table (field `exotic_be`) describing whether a species is exotic in Belgium.
+    Information is inferred from the GBIF checklist [Global Register of Introduced and Invasive Species - Belgium](https://www.gbif.org/dataset/6d9e952f-948c-4483-9807-575348147c7e).
+    The exotic status is propagatd to all children of a taxon, if present.  
 - Added vernacular names in `vernacularname` with all vernacular names. Adding only a subset of languages is possible
 - Improved the taxonomy table so rank info is also included (in a separate "rank" table)
 - Dropped the kingdom column in `taxonomy`: it's a cleaner design to infer it by browsing the tree (see below)

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -78,7 +78,7 @@ def populate_is_exotic_be_field(conn, config_parser, exotic_status_source):
                                                  exotic_taxa_list= exotic_taxa_ids,
                                                  depth=0)
 
-    msg(f"{len(exotic_taxa_ids)} exotic taxa found in taxonomy.")
+    msg = f"{len(exotic_taxa_ids)} exotic taxa found in taxonomy."
     print(msg)
     logging.info(msg)
 

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -99,6 +99,5 @@ if __name__ == "__main__":
     setup_log_file("./logs/populate_exotic_status_field.csv")
     # datasetKey of Global Register of Introduced and Invasive Species - Belgium
     griis_be = "6d9e952f-948c-4483-9807-575348147c7e"
-    populate_is_exotic_be_field(conn=connection,
-                                config_parser=config,
-                                exotic_status_source = griis_be)
+
+    populate_is_exotic_be_field(conn=connection, config_parser=config, exotic_status_source = griis_be)

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -1,0 +1,104 @@
+import logging
+import time
+from helpers import execute_sql_from_file, execute_sql_from_jinja_string, get_database_connection, get_config, setup_log_file, paginated_name_usage, print_indent
+
+def _get_alien_taxa(datasetKey):
+    """ Retrieve all taxa in GBIF checklist containing the exotic species in BE.
+    The function returns these taxa as a list of nubKey values (= GBIF taxon kayes from GBIF Backbone)"""
+
+    alien_taxa_in_be = paginated_name_usage(datasetKey=datasetKey)
+    alien_taxa_list = []
+    for taxon in alien_taxa_in_be:
+        nubKey = taxon.get('nubKey')
+        origin = taxon.get('origin')
+        if (nubKey is not None and origin == "SOURCE"):
+            alien_taxa_list += [nubKey]
+    return alien_taxa_list
+
+def _find_exotic_taxa(exotic_taxon, taxa, exotic_taxa_list, depth=0):
+    """ Function to search an exotic taxon in taxa and, recursively, all its children.
+
+    Params: depth is the recursion level (used for log indentation)
+
+    Returns a list of ids of exotic taxa in taxonomy table
+    """
+
+    if (exotic_taxon in taxa):
+        print_indent(
+            f"Taxon {taxa[exotic_taxon]['scientificName']} (gbifId: {exotic_taxon}) is exotic in Belgium.",
+            depth=depth)
+        id = taxa[exotic_taxon]['id']
+        exotic_taxa_list += [id]
+        for t in taxa.values():
+            if (t['parentId'] == id):
+                exotic_taxa_list = _find_exotic_taxa(exotic_taxon=t['gbifId'],
+                                                     taxa=taxa,
+                                                     exotic_taxa_list=exotic_taxa_list,
+                                                     depth=depth+1)
+    return exotic_taxa_list
+
+def populate_is_exotic_be_field(conn, config_parser, exotic_status_source):
+
+    msg = f"We'll now retrieve the GBIF checklist containing the exotic taxa in Belgium, datasetKey: {exotic_status_source}."
+    print(msg)
+    logging.info(msg)
+
+    start_time = time.time()
+    # get alien taxa from GRIIS Belgium checklist
+    alien_taxa = _get_alien_taxa(datasetKey=exotic_status_source)
+    end_time = time.time()
+
+    msg = f"Retrieved {len(alien_taxa)} exotic taxa in {end_time-start_time}s."
+    print(msg)
+    logging.info(msg)
+
+    taxon_cur = execute_sql_from_jinja_string(conn, "SELECT * FROM taxonomy", dict_cursor=True)
+
+    total_taxa_count = taxon_cur.rowcount
+    msg = f"We'll now update exotic_be field for {total_taxa_count} taxa of the taxonomy table."
+    print(msg)
+    logging.info(msg)
+
+    start_time = time.time()
+
+    taxa_to_check = dict()
+    for taxon in taxon_cur:
+        id = taxon['id']
+        parentId = taxon['parentId']
+        scientificName = taxon['scientificName']
+        gbifId = taxon['gbifId']
+        taxa_to_check[gbifId] = {'id': id, 'gbifId': gbifId, 'scientificName': scientificName, 'parentId': parentId}
+
+    exotic_taxa_ids= []
+
+    for exotic_taxon in alien_taxa:
+        exotic_taxa_ids = _find_exotic_taxa(exotic_taxon=exotic_taxon,
+                                                 taxa=taxa_to_check,
+                                                 exotic_taxa_list= exotic_taxa_ids,
+                                                 depth=0)
+
+    msg(f"{len(exotic_taxa_ids)} exotic taxa found in taxonomy.")
+    print(msg)
+    logging.info(msg)
+
+    # set exotic_be = True for exotic taxa and False for the others
+    template = """ UPDATE taxonomy SET "exotic_be" = """ \
+               + """ CASE WHEN "id" IN {{ ids | inclause }} THEN true""" \
+               + """ ELSE false END"""
+    update_exotic_be_cur = execute_sql_from_jinja_string(conn, sql_string=template, context={'ids': exotic_taxa_ids})
+
+    end_time = time.time()
+
+    msg = f"Field exotic_be updated for {update_exotic_be_cur.rowcount} taxa in taxonomy in {round(end_time - start_time)}s."
+    print(msg)
+    logging.info(msg)
+
+if __name__ == "__main__":
+    connection = get_database_connection()
+    config = get_config()
+    setup_log_file("./logs/populate_exotic_status_field.csv")
+    # datasetKey of Global Register of Introduced and Invasive Species - Belgium
+    griis_be = "6d9e952f-948c-4483-9807-575348147c7e"
+    populate_is_exotic_be_field(conn=connection,
+                                config_parser=config,
+                                exotic_status_source = griis_be)

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -49,7 +49,7 @@ def populate_is_exotic_be_field(conn, config_parser, exotic_status_source):
     alien_taxa = _get_alien_taxa(datasetKey=exotic_status_source)
     end_time = time.time()
 
-    msg = f"Retrieved {len(alien_taxa)} exotic taxa in {end_time-start_time}s."
+    msg = f"Retrieved {len(alien_taxa)} exotic taxa in {round(end_time-start_time)}s."
     print(msg)
     logging.info(msg)
 

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from helpers import execute_sql_from_file, execute_sql_from_jinja_string, get_database_connection, get_config, \
+from helpers import execute_sql_from_jinja_string, get_database_connection, get_config, \
     setup_log_file, paginated_name_usage, print_indent
 
 def _get_alien_taxa(datasetKey):

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -90,7 +90,7 @@ def populate_is_exotic_be_field(conn, config_parser, exotic_status_source):
 
     end_time = time.time()
 
-    msg = f"Field exotic_be updated for {update_exotic_be_cur.rowcount} taxa in taxonomy in {round(end_time - start_time)}s."
+    msg = f"Field exotic_be updated for {update_exotic_be_cur.rowcount} taxa in taxonomy in {round(end_time - start_time, 2)}s."
     print(msg)
     logging.info(msg)
 

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -1,6 +1,7 @@
 import logging
 import time
-from helpers import execute_sql_from_file, execute_sql_from_jinja_string, get_database_connection, get_config, setup_log_file, paginated_name_usage, print_indent
+from helpers import execute_sql_from_file, execute_sql_from_jinja_string, get_database_connection, get_config, \
+    setup_log_file, paginated_name_usage, print_indent
 
 def _get_alien_taxa(datasetKey):
     """ Retrieve all taxa in GBIF checklist containing the exotic species in BE.

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -3,8 +3,8 @@ import logging
 import pygbif
 import time
 import datetime
-from helpers import execute_sql_from_file, get_database_connection, get_config, setup_log_file
-from helpers import execute_sql_from_jinja_string
+from helpers import execute_sql_from_file, get_database_connection, get_config, setup_log_file, \
+    execute_sql_from_jinja_string, print_indent
 
 
 def _insert_or_get_rank(conn, rank_name):

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -112,10 +112,6 @@ def _get_taxon_from_taxonomy_by_gbifId(conn, gbif_id):
     return taxon
 
 
-def _print_indent(msg, depth=0, indent=4):
-    print("{}{}".format(" " * (indent * depth), msg))
-
-
 def _add_taxon_tree(conn, gbif_key, depth=0):
     # Params: depth is the recursion level (used for log indentation)
 
@@ -128,7 +124,7 @@ def _add_taxon_tree(conn, gbif_key, depth=0):
     gbif_parentKey = name_usage_info.get("parentKey")
     parent_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbif_id=gbif_parentKey)
 
-    _print_indent(f"Recursively adding the taxon with GBIF key {gbif_key} ({scientificName}) to the taxonomy table", depth=depth)
+    print_indent(f"Recursively adding the taxon with GBIF key {gbif_key} ({scientificName}) to the taxonomy table", depth=depth)
 
     taxon = {
         'gbifId': gbifId,
@@ -141,20 +137,20 @@ def _add_taxon_tree(conn, gbif_key, depth=0):
 
     if taxon_in_taxonomy.get('gbifId') is None:  # Taxon is not yet in our taxonomy table
         if gbif_parentKey is None:
-            _print_indent("According to GBIF, this is a root taxon (no more parents to insert)", depth=depth)
+            print_indent("According to GBIF, this is a root taxon (no more parents to insert)", depth=depth)
         else:
-            _print_indent("According to GBIF, this is *not* a root taxon, we'll insert parents first", depth=depth)
+            print_indent("According to GBIF, this is *not* a root taxon, we'll insert parents first", depth=depth)
             _add_taxon_tree(conn, gbif_key=gbif_parentKey, depth=depth+1)
             # get the updated parentId
             parent_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbif_id=gbif_parentKey)
             taxon['parentId'] = parent_in_taxonomy.get('id')
         newly_inserted_id = _insert_new_entry_taxonomy(conn, taxon=taxon)
-        _print_indent(f"Taxon {taxon['scientificName']} inserted in taxonomy (id = {newly_inserted_id}, parentId = {taxon['parentId']}).", depth=depth)
+        print_indent(f"Taxon {taxon['scientificName']} inserted in taxonomy (id = {newly_inserted_id}, parentId = {taxon['parentId']}).", depth=depth)
     else:  # The taxon already appears in the taxonomy table
-        _print_indent("This taxon already appears in the taxonomy table", depth=depth)
+        print_indent("This taxon already appears in the taxonomy table", depth=depth)
         if taxon.get('parentId') is None and gbif_parentKey is not None:  # it has no parent in taxonomy table, but GBIF has parent
             # TODO: check: is this whole case and code block necessary? (doesn't appear to be called with the test data)
-            _print_indent("But parents aren't there yet, inserting...", depth=depth)
+            print_indent("But parents aren't there yet, inserting...", depth=depth)
             _add_taxon_tree(conn, gbif_key=gbif_parentKey, depth=depth+1)
         # get the updated parentId
         parent_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbif_id=gbif_parentKey)

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -6,6 +6,7 @@ import psycopg2
 import psycopg2.extras
 from jinja2 import Environment
 from jinjasql import JinjaSql
+from pygbif import species
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
@@ -93,3 +94,23 @@ def execute_sql_from_file(conn, filename, context=None, dict_cursor=False):
                                          sql_string=open(os.path.join(dirname, 'sql_snippets', filename), 'r').read(),
                                          context=context,
                                          dict_cursor=dict_cursor)
+
+def paginated_name_usage(*args, **kwargs):
+    """Small helper to handle the pagination in pygbif and make sure we get all results in one shot"""
+    PER_PAGE = 100
+
+    results = []
+    offset = 0
+
+    while True:
+        resp = species.name_usage(*args, **kwargs, limit=PER_PAGE, offset=offset)
+        results = results + resp['results']
+        if resp['endOfRecords']:
+            break
+        else:
+            offset = offset + PER_PAGE
+
+    return results
+
+def print_indent(msg, depth=0, indent=4):
+    print("{}{}".format(" " * (indent * depth), msg))

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -10,7 +10,8 @@ CREATE TABLE taxonomy (
     "gbifId" integer NOT NULL UNIQUE, -- ID at GBIF
     "scientificName" character varying(255), -- as returned by GBIF
     "rankId" integer references rank(id),
-    "parentId" integer REFERENCES taxonomy(id)  -- internal (to the DB) pointer
+    "parentId" integer REFERENCES taxonomy(id),  -- internal (to the DB) pointer
+    "exotic_be" boolean -- as returned by GBIF (info from GRIIS Belgium checklist)
 );
 
 CREATE TYPE gbifmatchtype AS ENUM ('EXACT', 'FUZZY', 'HIGHERRANK', 'NONE');

--- a/scripts/sql_snippets/get_taxa_taxonomy.sql
+++ b/scripts/sql_snippets/get_taxa_taxonomy.sql
@@ -1,3 +1,4 @@
 SELECT * FROM taxonomy
-
--- TODO: replace this file by a string?
+{% if limit %}
+LIMIT {{ limit }}
+{% endif %};

--- a/scripts/sql_snippets/get_taxa_taxonomy_exotic_be_empty_only.sql
+++ b/scripts/sql_snippets/get_taxa_taxonomy_exotic_be_empty_only.sql
@@ -1,0 +1,5 @@
+SELECT * FROM taxonomy
+WHERE "exotic_be" is NULL
+{% if limit %}
+LIMIT {{ limit }}
+{% endif %};

--- a/scripts/sql_snippets/get_taxa_taxonomy_exotic_be_empty_only.sql
+++ b/scripts/sql_snippets/get_taxa_taxonomy_exotic_be_empty_only.sql
@@ -1,5 +1,0 @@
-SELECT * FROM taxonomy
-WHERE "exotic_be" is NULL
-{% if limit %}
-LIMIT {{ limit }}
-{% endif %};

--- a/scripts/transform_db.py
+++ b/scripts/transform_db.py
@@ -49,6 +49,6 @@ with conn:
     message = "Step 6: populate field exotic_be (values: True of False) from GRIIS checklist for each entry in taxonomy table."
     print(message)
     logging.info(message)
-    # datasetKey of Global Register of Introduced and Invasive Species - Belgium
+    # GBIF datasetKey of checklist: Global Register of Introduced and Invasive Species - Belgium
     griis_be = "6d9e952f-948c-4483-9807-575348147c7e"
     exotic_status.populate_is_exotic_be_field(conn, config_parser=config, exotic_status_source = griis_be)

--- a/scripts/transform_db.py
+++ b/scripts/transform_db.py
@@ -7,6 +7,7 @@
 import os
 import gbif_match
 import vernacular_names
+import exotic_status
 import logging
 
 from helpers import execute_sql_from_file, get_database_connection, get_config, setup_log_file
@@ -44,3 +45,10 @@ with conn:
     print(message)
     logging.info(message)
     vernacular_names.populate_vernacular_names(conn, empty_only=False)
+
+    message = "Step 6: populate field exotic_be (values: True of False) from GRIIS checklist for each entry in taxonomy table."
+    print(message)
+    logging.info(message)
+    # datasetKey of Global Register of Introduced and Invasive Species - Belgium
+    griis_be = "6d9e952f-948c-4483-9807-575348147c7e"
+    exotic_status.populate_is_exotic_be_field(conn=connection, config_parser=config, exotic_status_source = griis_be)

--- a/scripts/transform_db.py
+++ b/scripts/transform_db.py
@@ -51,4 +51,4 @@ with conn:
     logging.info(message)
     # datasetKey of Global Register of Introduced and Invasive Species - Belgium
     griis_be = "6d9e952f-948c-4483-9807-575348147c7e"
-    exotic_status.populate_is_exotic_be_field(conn=connection, config_parser=config, exotic_status_source = griis_be)
+    exotic_status.populate_is_exotic_be_field(conn, config_parser=config, exotic_status_source = griis_be)

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -28,7 +28,7 @@ def _get_vernacular_names_gbif(gbif_taxon_id, filter_lang=None):
     #  {'taxonKey': 5, 'vernacularName': 'schimmels', 'language': 'nld', 'country': 'BE',
     #   'source': 'Belgian Species List', 'sourceTaxonKey': 100489794}]
 
-    names_data = _paginated_name_usage(key=gbif_taxon_id, data="vernacularNames")
+    names_data = paginated_name_usage(key=gbif_taxon_id, data="vernacularNames")
 
     if filter_lang is not None:
         names_data = [nd for nd in names_data if nd['language'] in filter_lang]

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -3,26 +3,8 @@ import time
 
 from pygbif import species
 
-from helpers import execute_sql_from_jinja_string, get_database_connection, setup_log_file, get_config
-
-
-def _paginated_name_usage(*args, **kwargs):
-    """Small helper to handle the pagination in pygbif and make sure we get all results in one shot"""
-    PER_PAGE = 100
-
-    results = []
-    offset = 0
-
-    while True:
-        resp = species.name_usage(*args, **kwargs, limit=PER_PAGE, offset=offset)
-        results = results + resp['results']
-        if resp['endOfRecords']:
-            break
-        else:
-            offset = offset + PER_PAGE
-
-    return results
-
+from helpers import execute_sql_from_jinja_string, get_database_connection, setup_log_file, get_config, \
+    paginated_name_usage
 
 def _iso639_1_to_2(code):
     """Takes a 3 letter-code (fra) and returns the corresponding 2-letter code"""


### PR DESCRIPTION
This PR adds functionality to populate/update `exotic_be` field of `taxonomy`. Moved two functions from `vernacularnames.py` to `helpers.py` to be reused.

Exotiness information is retrieved from GRIIS Belgium checklist on GBIF and is inherited by all childern of an exotic taxon and it is implemented recursively.

Example:

Taxon Branta hutchinsii (Richardson, 1832) (gbifId: 5232452) is exotic in Belgium.
    Taxon Branta hutchinsii hutchinsii (gbifId: 7191099) is exotic in Belgium.


@niconoe: check it fast if you have time, otherwise I would merge it and review can happen at later stage as we spoked about it.