### PR TITLE
Implement synonymy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Development of the postgreSQL species database of Brussels Environment
 
 ## Changelog / development journal
 
+- Added field `acceptedId` to `taxonomy` table. If a taxon is a synonym in GBIF Backbone, the correspondent accepted 
+taxon is added and its `id` is used as value of `acceptedId`. Exotic status of synonyms is also inherited by the 
+correspondent accepted taxa.
 - Added exotic status to `taxonomy` table (field `exotic_be`) describing whether a species is exotic in Belgium.
     Information is inferred from the GBIF checklist [Global Register of Introduced and Invasive Species - Belgium](https://www.gbif.org/dataset/6d9e952f-948c-4483-9807-575348147c7e).
     The exotic status is propagatd to all children of a taxon, if present.  

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -31,11 +31,13 @@ def _find_exotic_taxa(exotic_taxon, taxa, exotic_taxa_list, depth=0):
         id = taxa[exotic_taxon]['id']
         exotic_taxa_list += [id]
         for t in taxa.values():
-            if (t['parentId'] == id):
+            # extend exotic status to all its children
+            if (id in [t['parentId'], t['acceptedId']]):
                 exotic_taxa_list = _find_exotic_taxa(exotic_taxon=t['gbifId'],
                                                      taxa=taxa,
                                                      exotic_taxa_list=exotic_taxa_list,
                                                      depth=depth+1)
+
     return exotic_taxa_list
 
 def populate_is_exotic_be_field(conn, config_parser, exotic_status_source):
@@ -68,8 +70,10 @@ def populate_is_exotic_be_field(conn, config_parser, exotic_status_source):
         parentId = taxon['parentId']
         scientificName = taxon['scientificName']
         gbifId = taxon['gbifId']
-        taxa_to_check[gbifId] = {'id': id, 'gbifId': gbifId, 'scientificName': scientificName, 'parentId': parentId}
+        acceptedId = taxon['acceptedId']
+        taxa_to_check[gbifId] = {'id': id, 'gbifId': gbifId, 'scientificName': scientificName, 'parentId': parentId, 'acceptedId': acceptedId}
 
+    #initialize list with id of exotic taxa in taxonomy
     exotic_taxa_ids= []
 
     for exotic_taxon in alien_taxa:

--- a/scripts/exotic_status.py
+++ b/scripts/exotic_status.py
@@ -82,10 +82,13 @@ def populate_is_exotic_be_field(conn, config_parser, exotic_status_source):
     print(msg)
     logging.info(msg)
 
-    # set exotic_be = True for exotic taxa and False for the others
-    template = """ UPDATE taxonomy SET "exotic_be" = """ \
-               + """ CASE WHEN "id" IN {{ ids | inclause }} THEN true""" \
-               + """ ELSE false END"""
+    if (len(exotic_taxa_ids) > 0):
+        # set exotic_be = True for exotic taxa and False for the others
+        template = """ UPDATE taxonomy SET "exotic_be" = """ \
+                   + """ CASE WHEN "id" IN {{ ids | inclause }} THEN true""" \
+                   + """ ELSE false END"""
+    else:
+        template = """ UPDATE taxonomy SET "exotic_be" = false"""
     update_exotic_be_cur = execute_sql_from_jinja_string(conn, sql_string=template, context={'ids': exotic_taxa_ids})
 
     end_time = time.time()

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -42,7 +42,9 @@ def _update_match_info(conn, match_info, scientificname_row_id):
     execute_sql_from_jinja_string(conn, sql_string=template, context=data)
 
 
-def _update_taxonomy_if_needed(conn, taxon_in_taxonomy, taxon):
+def _update_taxonomy_if_needed(conn, taxon_in_taxonomy, taxon, depth=0):
+    # Params: depth is the recursion level (used for log indentation)
+
     # GBIF knows about this taxon, and so we are. Do we need to update or do we already have the latest data
     gbifId = taxon['gbifId']
 
@@ -50,7 +52,7 @@ def _update_taxonomy_if_needed(conn, taxon_in_taxonomy, taxon):
     taxonomy_fields_to_compare = {k: taxon_in_taxonomy[k] for k in taxon}
     taxonomy_fields_to_change = taxonomy_fields_to_compare.copy()
     if taxon == taxonomy_fields_to_compare:
-        print(f"Taxon {taxon['scientificName']} already present in taxonomy (id = {taxonomyId}).")
+        print_indent(f"Taxon {taxon['scientificName']} already present in taxonomy (id = {taxonomyId}).", depth)
     else:
         # unchanged fields
         keys_same_values = dict(taxonomy_fields_to_compare.items() & taxon.items()).keys()

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -223,6 +223,13 @@ def gbif_match(conn, config_parser, unmatched_only=True):
 
         print(f"Add match information (and taxonomiyId, if a match was found) to scientificname for {name} (id: {row_id}).")
         _update_match_info(conn, match_info, row_id)
+        if (row_id % 10 == 9) and (row_id < total_sn_count - 1): # Get time info after multiple of 10 taxa
+            elapsed_time = time.time() - start
+            # notice expected time as calculated below is highly overestimated at the beginning as all trees up to
+            # kingdoms have to be built at the beginning
+            expected_time = elapsed_time / (row_id + 1) * (total_sn_count - row_id - 1)
+            print(f"{row_id + 1}/{total_sn_count} taxa handled in {round(elapsed_time, 2)}s. Expected time to go: {expected_time}s.")
+
 
     # Logging and statistics
     end = time.time()

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -150,10 +150,6 @@ def _add_taxon_tree(conn, gbif_key, depth=0):
         print_indent(f"Taxon {taxon['scientificName']} inserted in taxonomy (id = {newly_inserted_id}, parentId = {taxon['parentId']}).", depth=depth)
     else:  # The taxon already appears in the taxonomy table
         print_indent("This taxon already appears in the taxonomy table", depth=depth)
-        if taxon.get('parentId') is None and gbif_parentKey is not None:  # it has no parent in taxonomy table, but GBIF has parent
-            # TODO: check: is this whole case and code block necessary? (doesn't appear to be called with the test data)
-            print_indent("But parents aren't there yet, inserting...", depth=depth)
-            _add_taxon_tree(conn, gbif_key=gbif_parentKey, depth=depth+1)
         # get the updated parentId
         parent_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbif_id=gbif_parentKey)
         taxon['parentId'] = parent_in_taxonomy.get('id')

--- a/scripts/gbif_match.py
+++ b/scripts/gbif_match.py
@@ -151,7 +151,7 @@ def _add_taxon_tree(conn, gbif_key, depth=0):
             parent_in_taxonomy = _get_taxon_from_taxonomy_by_gbifId(conn, gbif_id=gbif_parentKey)
             taxon['parentId'] = parent_in_taxonomy.get('id')
         if gbif_acceptedKey is None:
-            print_indent("According to GBIF, this is *not* a synonym (no accepetd taxon to insert)", depth=depth)
+            print_indent("According to GBIF, this is *not* a synonym (no accepted taxon to insert)", depth=depth)
         else:
             print_indent("According to GBIF, this is a synonym. We'll insert accepted taxon first", depth=depth)
             _add_taxon_tree(conn, gbif_key=gbif_acceptedKey, depth=depth + 1)

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE taxonomy (
     "gbifId" integer NOT NULL UNIQUE, -- ID at GBIF
     "scientificName" character varying(255), -- as returned by GBIF
     "rankId" integer references rank(id),
+    "acceptedId" integer REFERENCES taxonomy(id), -- internal (to the DB) pointer
     "parentId" integer REFERENCES taxonomy(id),  -- internal (to the DB) pointer
     "exotic_be" boolean -- as returned by GBIF (info from GRIIS Belgium checklist)
 );

--- a/scripts/transform_db.py
+++ b/scripts/transform_db.py
@@ -29,7 +29,7 @@ with conn:
     logging.info(message)
     execute_sql_from_file(conn, 'create_new_tables.sql')
 
-    message = "Step 3: populate the scientifcname tables based on the actual content"
+    message = "Step 3: populate the scientificname tables based on the actual content"
     print(message)
     logging.info(message)
     execute_sql_from_file(conn, 'populate_scientificname.sql',


### PR DESCRIPTION
This PR implements synonymy in taxonomy table so fixing #17.

After adding (if not already present) the parents up to kingdom, the related accepted taxon of a synonym is added to taxonomy.
Changes were actually reasonably minimal (https://github.com/inbo/speciesbim/commit/204f315d484263c611bb8c011c7be2de81f03756), which means functions were well written! :clap: for us!

The exotic status of a taxon from the GRIIS Belgium is not only inherited by its children, but also by its synonyms, if any.

Positively tested on all names.

Other minor changes:
1. Small bug solved in the SQL query for filling `exotic_be` field.SQL query crashed if no exotic taxa are present, which can occur when testing all on a very limited number of taxa (https://github.com/inbo/speciesbim/commit/a51b4d8e87e4e0a0a6b38634085972838fe0c49b).
2. Indentation of the log improved by adding argument `depth` to function `_update_taxonomy_if_needed` as well (https://github.com/inbo/speciesbim/commit/c370cf13ea710c10289f83c81f2f19f645becf69)
3. Add updates on screen while matching taxa to give the user some ideas about remaining time and number of taxa left at every multiple of 10 taxa (https://github.com/inbo/speciesbim/commit/c370cf13ea710c10289f83c81f2f19f645becf69).
3. Run in debug modus on all taxa and I could verify that the chunk code in could be removed safely as @niconoe proposed (https://github.com/inbo/speciesbim/commit/9eceb93bd9c0735d91cb64360b1a54d215c189f3).