### PR TITLE
Add language as input from user

### DIFF
--- a/scripts/transform_db.py
+++ b/scripts/transform_db.py
@@ -44,7 +44,9 @@ with conn:
     message = "Step 5: populate vernacular names from GBIF for each entry in the taxonomy table"
     print(message)
     logging.info(message)
-    vernacular_names.populate_vernacular_names(conn, config_parser=config, empty_only=False)
+    # list of 2-letters language codes (ISO 639-1)
+    languages = ['fr', 'nl', 'en']
+    vernacular_names.populate_vernacular_names(conn, config_parser=config, empty_only=False, filter_lang=languages)
 
     message = "Step 6: populate field exotic_be (values: True of False) from GRIIS checklist for each entry in taxonomy table."
     print(message)

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -7,7 +7,7 @@ from helpers import execute_sql_from_jinja_string, get_database_connection, setu
     paginated_name_usage
 
 def _iso639_1_to_2(code):
-    """Takes a 3 letter-code (fra) and returns the corresponding 2-letter code"""
+    """Takes a 3 letter-code (fra) and returns the corresponding 2-letter code (fr)"""
     c = {'fra': 'fr',
          'fre': 'fr',
          'nld': 'nl',

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -94,7 +94,8 @@ def populate_vernacular_names(conn, config_parser, empty_only, filter_lang=None)
             name = vernacular_name.get('vernacularName')
             lang_code = filter_lang_dict[vernacular_name.get('language')]
             source = vernacular_name.get('source')
-
+            if source is None:
+                print(f"Warning: vernacular name {name} for taxon with ID: {taxonomy_id} without source. Contact GBIF: https://github.com/gbif/gbif-api/issues/56")
             msg = f"Now saving '{name}'({lang_code}) for taxon with ID: {taxonomy_id} (source: {source})"
             print(msg)
             logging.info(msg)

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -1,6 +1,6 @@
 import logging
 import time
-
+from pycountry import languages as pylang
 
 from helpers import execute_sql_from_jinja_string, get_database_connection, setup_log_file, get_config, \
     paginated_name_usage

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -14,8 +14,6 @@ def _iso639_1_to_2_dict(lang):
         {'fra': 'fr',
          'fre': 'fr',
          'nld': 'nl',
-def _get_vernacular_names_gbif(gbif_taxon_id, filter_lang=None):
-    # filter_lang is a list of language codes (ISO 639-2 Code) (default: no filtering)
          'dut': 'nl'}
         """
     languages_info = [pylang.get(alpha_2=l) for l in lang]
@@ -29,6 +27,9 @@ def _get_vernacular_names_gbif(gbif_taxon_id, filter_lang=None):
     gbif_languages = dict(gbif_languages)
     return gbif_languages
 
+def _get_vernacular_names_gbif(gbif_taxon_id, languages3=None):
+    # languages3 is a list of 3-letter language codes (ISO 639-1 Code) (default: no filtering)
+    # GBIF uses ISO 639-2 codes (3-letters format)
     # !! Synonyms !!: GBIF uses 'fra' for french and 'nld' for dutch
     # example: ['fra', 'nld']
 
@@ -41,8 +42,8 @@ def _get_vernacular_names_gbif(gbif_taxon_id, filter_lang=None):
 
     names_data = paginated_name_usage(key=gbif_taxon_id, data="vernacularNames")
 
-    if filter_lang is not None:
-        names_data = [nd for nd in names_data if nd['language'] in filter_lang]
+    if languages3 is not None:
+        names_data = [nd for nd in names_data if nd['language'] in languages3]
 
     return names_data
 

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -117,5 +117,6 @@ if __name__ == "__main__":
     connection = get_database_connection()
     config = get_config()
     setup_log_file("./logs/vernacular_names.csv")
-
-    populate_vernacular_names(connection, config_parser=config, empty_only=False)
+    # list of 2-letters language codes (ISO 639-1)
+    languages = ['fr', 'nl', 'en']
+    populate_vernacular_names(connection, config_parser=config, empty_only=False, filter_lang=languages)

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -5,19 +5,30 @@ from pycountry import languages as pylang
 from helpers import execute_sql_from_jinja_string, get_database_connection, setup_log_file, get_config, \
     paginated_name_usage
 
-def _iso639_1_to_2(code):
-    """Takes a 3 letter-code (fra) and returns the corresponding 2-letter code (fr)"""
-    c = {'fra': 'fr',
+def _iso639_1_to_2_dict(lang):
+    """
+    Takes some 2 letter-code languages (['fr', 'nl']).
+    Returns a dictionary with the corresponding 3-letter codes ('fra', 'nld') and bibliogaphic synonyms ('fre', 'dut')
+    as keys, the corresponding 2-leter-code languages as values.
+    Example:
+        {'fra': 'fr',
          'fre': 'fr',
          'nld': 'nl',
-         'dut': 'nl',
-         'eng': 'en'}
-
-    return c.get(code)
-
-
 def _get_vernacular_names_gbif(gbif_taxon_id, filter_lang=None):
     # filter_lang is a list of language codes (ISO 639-2 Code) (default: no filtering)
+         'dut': 'nl'}
+        """
+    languages_info = [pylang.get(alpha_2=l) for l in lang]
+    # attributes to search for in a language object
+    attributes = ['alpha_3', 'bibliographic']
+    # create a dictionary with 3-letters as keys and 2-letter format as values
+    # something like {'fra': 'fr', 'fre': 'fr', 'nld': 'nl', 'dut': 'nl', 'eng': 'en'}
+    gbif_languages = [(getattr(language_info, i), getattr(language_info, "alpha_2")) for language_info in languages_info
+                      for i in attributes if
+                      i in dir(language_info)]
+    gbif_languages = dict(gbif_languages)
+    return gbif_languages
+
     # !! Synonyms !!: GBIF uses 'fra' for french and 'nld' for dutch
     # example: ['fra', 'nld']
 

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -1,7 +1,6 @@
 import logging
 import time
 
-from pygbif import species
 
 from helpers import execute_sql_from_jinja_string, get_database_connection, setup_log_file, get_config, \
     paginated_name_usage

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -11,7 +11,8 @@ def _iso639_1_to_2(code):
     c = {'fra': 'fr',
          'fre': 'fr',
          'nld': 'nl',
-         'dut': 'nl'}
+         'dut': 'nl',
+         'eng': 'en'}
 
     return c.get(code)
 


### PR DESCRIPTION
This PR solves issue #24 by allowing the user to choose which languages (expressed as two-letter format, iso639-1) should be selected while filtering the GBIF vernacular names. so avoiding to hard code the languages to select and the conversion two-three letter format languages.

To do this I used module `languages` from package `pycountry`. Example about this module:

```python
> a = pylang.get(alpha_2 = "nl")
> print(a)
Language(alpha_2='nl', alpha_3='nld', bibliographic='dut', name='Dutch', scope='I', type='L')
> b = pylang.get(alpha_2 = "fr") 
> print(b)
Language(alpha_2='fr', alpha_3='fra', bibliographic='fre', name='French', scope='I', type='L')
> c = pylang.get(alpha_2 = "en")
> print(c)
Language(alpha_2='en', alpha_3='eng', name='English', scope='I', type='L')
 ```

As marked earlier (#14 ) by @niconoe, GBIF seems to use ALWAYS alpha_3 values, but he thought to program defensively by not excluding the use of `synonyms`, e.g. `dut` for alpha-3 `nld` and `fre` for alpha_3 `fra`. In this new approach, the so called synonyms are the values of of the attribute `bibliographic`. 