### PR TITLE
Add vernacularnamesource table and store datasetKey

### DIFF
--- a/EXAMPLE_QUERIES.md
+++ b/EXAMPLE_QUERIES.md
@@ -125,32 +125,31 @@ SELECT * FROM subtaxa WHERE "treeTop" = 5;
 | 8 | 5 | Rana ridibunda Pallas, 1771 | 6 |
 | 7 | 5 | Pelophylax ridibundus \(Pallas, 1771\) | 6 |
 
-
+    
 # Example 4: Get 2 vernacularnames for a given taxon, priority to names from the Belgian Species List
 
 ```
-WITH vernacularnames_with_priority AS (
+WITH vernacularnames_sources_with_priority AS (
     SELECT
-           "taxonomyId",
-           "language",
-           "name",
-           "source",
+           "id",
+           "datasetKey",
+           "datasetTitle",
            (CASE
-               WHEN "source" LIKE 'Belgian Species List' THEN TRUE
+               WHEN "datasetTitle" LIKE 'Belgian Species List' THEN TRUE
                ELSE FALSE END
             ) "high_priority_source"
-    FROM biodiv.vernacularname
+        FROM biodiv.vernacularnamesource
     )
 
-
-SELECT * FROM vernacularnames_with_priority
-WHERE "taxonomyId" = 8 -- Marsh frog;
-AND language LIKE 'fr'
+SELECT * FROM biodiv.vernacularname
+LEFT JOIN vernacularnames_sources_with_priority v on v.id = vernacularname.source
+WHERE "taxonomyId" = 8 AND language LIKE 'fr'
 ORDER by high_priority_source DESC -- High priority source first
 LIMIT 2;
 ```
 
-| taxonomyId | language | name | source | high\_priority\_source |
-| :--- | :--- | :--- | :--- | :--- |
-| 8 | fr | grenouille rieuse | Belgian Species List | true |
-| 8 | fr | Grenouille rieuse | EUNIS Biodiversity Database | false |
+| id | taxonomyId | language | name | source | id | datasetKey | datasetTitle | high\_priority\_source |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| 39 | 8 | fr | grenouille rieuse | 4 | 4 | 39653f3e-8d6b-4a94-a202-859359c164c5 | Belgian Species List | true |
+| 37 | 8 | fr | Grenouille rieuse | 37 | 37 | 1bd42c2b-b58a-4a01-816b-bec8c8977927 | EUNIS Biodiversity Database | false |
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Development of the postgreSQL species database of Brussels Environment
 
 ## Changelog / development journal
 
-- Store details (`datasetKey` and `datasetTitle`) about datasets vernacular names come from in a new table called `verncaularnamesource`
+- Store details (`datasetKey` and `datasetTitle`) about the source (dataset) of vernacular names in a new table (`verncaularnamesource`)
 - Add functionality of running existing code in a demo mode to showcase the work done up to now on a small but significant subset of taxa
 - Create a table called scientificnameannex and write functionality to populate with taxa in `official_annexes.csv`
 - Add text file, `official_annexes.csv`, in `data/raw` containing all taxa mentioned in official annexes and ordinances

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Development of the postgreSQL species database of Brussels Environment
 
 ## Changelog / development journal
 
+- Store details (`datasetKey` and `datasetTitle`) about datasets vernacular names come from in a new table called `verncaularnamesource`
 - Add functionality of running existing code in a demo mode to showcase the work done up to now on a small but significant subset of taxa
 - Create a table called scientificnameannex and write functionality to populate with taxa in `official_annexes.csv`
 - Add text file, `official_annexes.csv`, in `data/raw` containing all taxa mentioned in official annexes and ordinances

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -42,10 +42,16 @@ CREATE TABLE scientificnameannex (
     "matchType" gbifmatchtype
 );
 
+CREATE TABLE vernacularnamesource (
+    "id" serial PRIMARY KEY,
+    "datasetKey" character varying(50) UNIQUE, -- alphanumeric GBIF datasetKey (UUID)
+    "datasetTitle" character varying (511) UNIQUE -- as appears in GBIF
+);
+
 CREATE TABLE vernacularname (
     "id" serial PRIMARY KEY,
     "taxonomyId" integer REFERENCES taxonomy(id) NOT NULL, -- Can be null if no match
     "language" character varying(2) NOT NULL, -- Follows ISO 639-1 standard
     "name" character varying(255) NOT NULL,
-    "source" character varying(255)
+    "source" integer REFERENCES vernacularnamesource(id) -- GBIF datasetKey (UUID)
 )

--- a/scripts/sql_snippets/create_new_tables.sql
+++ b/scripts/sql_snippets/create_new_tables.sql
@@ -45,7 +45,7 @@ CREATE TABLE scientificnameannex (
 CREATE TABLE vernacularnamesource (
     "id" serial PRIMARY KEY,
     "datasetKey" character varying(50) UNIQUE, -- alphanumeric GBIF datasetKey (UUID)
-    "datasetTitle" character varying (511) UNIQUE -- as appears in GBIF
+    "datasetTitle" character varying (1023) UNIQUE -- as appears in GBIF
 );
 
 CREATE TABLE vernacularname (
@@ -53,5 +53,5 @@ CREATE TABLE vernacularname (
     "taxonomyId" integer REFERENCES taxonomy(id) NOT NULL, -- Can be null if no match
     "language" character varying(2) NOT NULL, -- Follows ISO 639-1 standard
     "name" character varying(255) NOT NULL,
-    "source" integer REFERENCES vernacularnamesource(id) -- GBIF datasetKey (UUID)
+    "source" integer REFERENCES vernacularnamesource(id)
 )

--- a/scripts/sql_snippets/drop_new_tables_if_exists.sql
+++ b/scripts/sql_snippets/drop_new_tables_if_exists.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS vernacularname;
+DROP TABLE IF EXISTS vernacularnamesource;
 DROP TABLE IF EXISTS scientificname;
 DROP TABLE IF EXISTS scientificnameannex;
 DROP TYPE IF EXISTS gbifmatchtype;

--- a/scripts/vernacular_names.py
+++ b/scripts/vernacular_names.py
@@ -50,6 +50,7 @@ def _get_vernacular_names_gbif(gbif_taxon_id, languages3=None):
 
     return names_data
 
+
 def _insert_or_get_vernacularnamesource(conn, uuid, title):
     """ Insert or select a dataset based on its datasetKey (UUID)
 
@@ -73,6 +74,7 @@ def _insert_or_get_vernacularnamesource(conn, uuid, title):
                                         sql_string=dataset_template,
                                         context={'uuid': uuid, 'title': title})
     return cur.fetchone()[0]
+
 
 def populate_vernacular_names(conn, config_parser, empty_only, filter_lang=None):
     # If empty only, only process the taxa currently without vernacular names


### PR DESCRIPTION
This PR is my attempt to solve #19 .

The field `source` in `vernacularname` table is a foreign key to the serial primary key `id` of the new `vernacularnamesource` table where the `datasetKey` and `datasetTitle` of the checklist the names come from are stored.
I used the nice work of @niconoe on `rank` table as template :+1: 